### PR TITLE
Update angular dependency to 4.0.0-alpha

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,13 @@ sudo: false
 dart:
   - dev
   - stable
-  - 1.23.0
 dart_task:
   - dartanalyzer: --fatal-warnings .
   - dartfmt
 cache:
   directories:
     - $HOME/.pub-cache
+matrix:
+  allow_failures:
+  - dart: dev
+    dart_task: dartfmt

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,10 +1,12 @@
 analyzer:
  strong-mode: true
  errors:
-   unused_element: error
-   unused_import: error
-   unused_local_variable: error
-   dead_code: error
+  # TODO(nshahan) Make these errors when there is a fix for
+  # https://github.com/dart-lang/sdk/issues/29713
+  unused_element: warning
+  unused_import: warning
+  unused_local_variable: warning
+  dead_code: warning
 linter:
   rules:
     #- always_declare_return_types

--- a/lib/app_component.dart
+++ b/lib/app_component.dart
@@ -1,7 +1,7 @@
 // Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
-import 'package:angular2/angular2.dart';
+import 'package:angular/angular.dart';
 import 'package:angular_components/angular_components.dart';
 
 import 'src/demo_app/demo_app.dart';

--- a/lib/src/demo_app/demo_app.dart
+++ b/lib/src/demo_app/demo_app.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:angular2/angular2.dart';
+import 'package:angular/angular.dart';
 import 'package:angular_components/angular_components.dart';
 
 @Component(

--- a/lib/src/glyph_demo/glyph_demo.dart
+++ b/lib/src/glyph_demo/glyph_demo.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:angular2/angular2.dart';
+import 'package:angular/angular.dart';
 import 'package:angular_components/angular_components.dart';
 
 @Component(

--- a/lib/src/material_button_demo/material_button_demo.dart
+++ b/lib/src/material_button_demo/material_button_demo.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:angular2/angular2.dart';
+import 'package:angular/angular.dart';
 import 'package:angular_components/angular_components.dart';
 
 @Component(

--- a/lib/src/material_checkbox_demo/material_checkbox_demo.dart
+++ b/lib/src/material_checkbox_demo/material_checkbox_demo.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:angular2/angular2.dart';
+import 'package:angular/angular.dart';
 import 'package:angular_components/angular_components.dart';
 
 @Component(

--- a/lib/src/material_chips_demo/material_chips_demo.dart
+++ b/lib/src/material_chips_demo/material_chips_demo.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:angular2/angular2.dart';
+import 'package:angular/angular.dart';
 import 'package:angular_components/angular_components.dart';
 
 @Component(

--- a/lib/src/material_dialog_demo/material_dialog_demo.dart
+++ b/lib/src/material_dialog_demo/material_dialog_demo.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:angular2/angular2.dart';
+import 'package:angular/angular.dart';
 import 'package:angular_components/angular_components.dart';
 
 @Component(

--- a/lib/src/material_expansionpanel_demo/material_expansionpanel_demo.dart
+++ b/lib/src/material_expansionpanel_demo/material_expansionpanel_demo.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:angular2/angular2.dart';
+import 'package:angular/angular.dart';
 import 'package:angular_components/angular_components.dart';
 
 @Component(

--- a/lib/src/material_input_demo/material_input_demo.dart
+++ b/lib/src/material_input_demo/material_input_demo.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:angular2/angular2.dart';
+import 'package:angular/angular.dart';
 import 'package:angular_components/angular_components.dart';
 
 @Component(

--- a/lib/src/material_list_demo/material_list_demo.dart
+++ b/lib/src/material_list_demo/material_list_demo.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:angular2/angular2.dart';
+import 'package:angular/angular.dart';
 import 'package:angular_components/angular_components.dart';
 
 @Component(

--- a/lib/src/material_list_demo/material_list_demo.html
+++ b/lib/src/material_list_demo/material_list_demo.html
@@ -29,7 +29,7 @@
 <p>Available Sizes: auto, x-small, small, medium, large, x-large</p>
 <div *ngFor="let size of sizes">
   <material-list class="bordered-list"
-                 [attr.size]="size">
+                 [size]="size">
     <div label>List Width: {{size}}</div>
     <material-list-item (trigger)="selectColor('red')">
       Red

--- a/lib/src/material_popup_demo/material_popup_demo.dart
+++ b/lib/src/material_popup_demo/material_popup_demo.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:angular2/angular2.dart';
+import 'package:angular/angular.dart';
 import 'package:angular_components/angular_components.dart';
 
 @Component(

--- a/lib/src/material_progress_demo/material_progress_demo.dart
+++ b/lib/src/material_progress_demo/material_progress_demo.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:angular2/angular2.dart';
+import 'package:angular/angular.dart';
 import 'package:angular_components/angular_components.dart';
 
 @Component(

--- a/lib/src/material_radio_demo/material_radio_demo.dart
+++ b/lib/src/material_radio_demo/material_radio_demo.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:angular2/angular2.dart';
+import 'package:angular/angular.dart';
 import 'package:angular_components/angular_components.dart';
 
 @Component(

--- a/lib/src/material_select_demo/material_select_demo.dart
+++ b/lib/src/material_select_demo/material_select_demo.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:angular2/angular2.dart';
+import 'package:angular/angular.dart';
 import 'package:angular_components/angular_components.dart';
 
 @Component(

--- a/lib/src/material_spinner_demo/material_spinner_demo.dart
+++ b/lib/src/material_spinner_demo/material_spinner_demo.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:angular2/angular2.dart';
+import 'package:angular/angular.dart';
 import 'package:angular_components/angular_components.dart';
 
 @Component(

--- a/lib/src/material_tab_demo/material_tab_demo.dart
+++ b/lib/src/material_tab_demo/material_tab_demo.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:angular2/angular2.dart';
+import 'package:angular/angular.dart';
 import 'package:angular_components/angular_components.dart';
 
 @Component(

--- a/lib/src/material_toggle_demo/material_toggle_demo.dart
+++ b/lib/src/material_toggle_demo/material_toggle_demo.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:angular2/angular2.dart';
+import 'package:angular/angular.dart';
 import 'package:angular_components/angular_components.dart';
 
 @Component(

--- a/lib/src/material_tooltip_demo/material_tooltip_demo.dart
+++ b/lib/src/material_tooltip_demo/material_tooltip_demo.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:angular2/angular2.dart';
+import 'package:angular/angular.dart';
 import 'package:angular_components/angular_components.dart';
 
 @Component(

--- a/lib/src/material_tree_demo/material_tree_demo.dart
+++ b/lib/src/material_tree_demo/material_tree_demo.dart
@@ -1,5 +1,5 @@
 import 'package:angular_components/angular_components.dart';
-import 'package:angular2/angular2.dart';
+import 'package:angular/angular.dart';
 
 /// An example that renders a [MaterialTreeComponent] with nested options.
 ///

--- a/lib/src/material_yes_no_buttons_demo/material_yes_no_buttons_demo.dart
+++ b/lib/src/material_yes_no_buttons_demo/material_yes_no_buttons_demo.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:angular2/angular2.dart';
+import 'package:angular/angular.dart';
 import 'package:angular_components/angular_components.dart';
 
 @Component(

--- a/lib/src/reorder_list_demo/reorder_list_demo.dart
+++ b/lib/src/reorder_list_demo/reorder_list_demo.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:angular2/angular2.dart';
+import 'package:angular/angular.dart';
 import 'package:angular_components/angular_components.dart';
 
 @Component(

--- a/lib/src/scorecard_demo/scorecard_demo.dart
+++ b/lib/src/scorecard_demo/scorecard_demo.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:angular2/angular2.dart';
+import 'package:angular/angular.dart';
 import 'package:angular_components/angular_components.dart';
 
 @Component(

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,24 +7,30 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.30.0+2"
-  angular2:
+  angular:
     description:
-      name: angular2
+      name: angular
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.1.0"
+    version: "4.0.0-alpha"
+  angular_compiler:
+    description:
+      name: angular_compiler
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.1"
   angular_components:
     description:
       name: angular_components
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.5.3"
+    version: "0.6.0-alpha"
   archive:
     description:
       name: archive
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.29"
+    version: "1.0.31"
   args:
     description:
       name: args
@@ -72,13 +78,13 @@ packages:
       name: cli_util
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.1"
+    version: "0.1.2"
   code_builder:
     description:
       name: code_builder
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.3"
+    version: "1.0.4"
   code_transformers:
     description:
       name: code_transformers
@@ -90,7 +96,7 @@ packages:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.14.1"
+    version: "1.14.2"
   convert:
     description:
       name: convert
@@ -108,19 +114,19 @@ packages:
       name: csslib
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.13.7+1"
+    version: "0.14.0"
   dart_style:
     description:
       name: dart_style
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.6"
+    version: "1.0.7"
   dart_to_js_script_rewriter:
     description:
       name: dart_to_js_script_rewriter
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.2"
+    version: "1.0.3"
   fixnum:
     description:
       name: fixnum
@@ -150,13 +156,13 @@ packages:
       name: html
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.13.1"
+    version: "0.13.2"
   intl:
     description:
       name: intl
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.15.0"
+    version: "0.15.1"
   isolate:
     description:
       name: isolate
@@ -192,7 +198,7 @@ packages:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.5"
+    version: "1.1.0"
   observable:
     description:
       name: observable
@@ -210,7 +216,7 @@ packages:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.4.1"
+    version: "1.4.2"
   perf_api:
     description:
       name: perf_api
@@ -229,24 +235,24 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.3.1"
-  protobuf:
-    description:
-      name: protobuf
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.5.4"
   quiver:
     description:
       name: quiver
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.25.0"
+  quiver_hashcode:
+    description:
+      name: quiver_hashcode
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.0"
   source_gen:
     description:
       name: source_gen
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.5.7"
+    version: "0.6.1+1"
   source_maps:
     description:
       name: source_maps
@@ -264,13 +270,19 @@ packages:
       name: stack_trace
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.7.3"
+    version: "1.8.0"
   string_scanner:
     description:
       name: string_scanner
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.2"
+  tuple:
+    description:
+      name: tuple
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.1"
   typed_data:
     description:
       name: typed_data
@@ -314,4 +326,4 @@ packages:
     source: hosted
     version: "2.1.12"
 sdks:
-  dart: ">=1.23.0 <2.0.0"
+  dart: ">=1.24.0 <2.0.0-dev.infinity"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,16 +1,16 @@
 name: angular_components_example
 description: An example app using the angular_components package.
 environment:
-  sdk: '>=1.23.0 <2.0.0'
+  sdk: '>=1.24.0 <2.0.0-dev.infinity'
 dependencies:
-  angular2: ^3.0.0
-  angular_components: ^0.5.3
+  angular: '4.0.0-alpha'
+  angular_components: '0.6.0-alpha'
   browser: ^0.10.0
   dart_to_js_script_rewriter: ^1.0.1
 dev_dependencies:
   webdriver: ^1.2.1
 transformers:
-- angular2:
+- angular:
     entry_points: web/main.dart
 - $dart2js:
     commandLineOptions: [--trust-type-annotations, --trust-primitives, --show-package-warnings, --dump-info]

--- a/web/main.dart
+++ b/web/main.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:angular2/platform/browser.dart';
+import 'package:angular/angular.dart';
 import 'package:angular_components_example/app_component.dart';
 
 main() {


### PR DESCRIPTION
* Fix Material List example.
* Update SDK dependencies.
* Remove SDK 1.23 from travis matrix.
* Allow dartfmt to fail with dev SDK on Travis.