### PR TITLE
Support build runner

### DIFF
--- a/lib/src/material_auto_suggest_input_demo/material_auto_suggest_input_demo.dart
+++ b/lib/src/material_auto_suggest_input_demo/material_auto_suggest_input_demo.dart
@@ -13,8 +13,10 @@ import 'package:angular_components/model/selection/select.dart';
 import 'package:angular_components/model/selection/selection_model.dart';
 import 'package:angular_components/model/selection/selection_options.dart';
 import 'package:angular_components/model/selection/string_selection_options.dart';
-import 'package:angular_components/model/ui/has_renderer.dart';
+import 'package:angular_components/model/ui/has_factory.dart';
 import 'package:angular_forms/angular_forms.dart';
+
+import 'material_auto_suggest_input_demo.template.dart' as demo;
 
 List<String> _numberNames = <String>[
   'one',
@@ -107,8 +109,8 @@ class MaterialAutoSuggestInputDemoComponent {
   bool showClearIcon = false;
   bool hideCheckbox = false;
   bool shouldClearOnSelection = false;
-  bool useLabelRenderer = false;
-  bool useComponentRenderer = false;
+  bool useLabelFactory = false;
+  bool useFactoryRenderer = false;
   bool disabled = false;
   String label = 'Search...';
   String emptyPlaceholder = 'No matches';
@@ -128,11 +130,12 @@ class MaterialAutoSuggestInputDemoComponent {
 
   ItemRenderer<List<int>> get itemRenderer => _numberNameRenderer;
 
-  ComponentRenderer get componentRenderer =>
-      useComponentRenderer ? (_) => ExampleRendererComponent : null;
+  FactoryRenderer get factoryRenderer =>
+      useFactoryRenderer ? (_) => demo.ExampleRendererComponentNgFactory : null;
 
-  ComponentRenderer get labelRenderer =>
-      useLabelRenderer ? (_) => ExampleLabelRendererComponent : null;
+  FactoryRenderer get labelFactory => useLabelFactory
+      ? (_) => demo.ExampleLabelRendererComponentNgFactory
+      : null;
 
   String get popupPositionSelectButtonText =>
       popupPositionSelection.selectedValues.isNotEmpty

--- a/lib/src/material_auto_suggest_input_demo/material_auto_suggest_input_demo.html
+++ b/lib/src/material_auto_suggest_input_demo/material_auto_suggest_input_demo.html
@@ -14,13 +14,13 @@
         [showClearIcon]="showClearIcon"
         [shouldClearOnSelection]="shouldClearOnSelection"
         [label]="label"
-        [labelRenderer]="labelRenderer"
+        [labelFactory]="labelFactory"
         [leadingGlyph]="leadingGlyph"
         [emptyPlaceholder]="emptyPlaceholder"
         [selection]="singleModel"
         [selectionOptions]="options"
         [itemRenderer]="itemRenderer"
-        [componentRenderer]="componentRenderer"
+        [factoryRenderer]="factoryRenderer"
         [popupPositions]="popupPositions"
         [limit]="limit"
         [disabled]="disabled">
@@ -39,13 +39,13 @@
         [hideCheckbox]="hideCheckbox"
         [shouldClearOnSelection]="shouldClearOnSelection"
         [label]="label"
-        [labelRenderer]="labelRenderer"
+        [labelFactory]="labelFactory"
         [leadingGlyph]="leadingGlyph"
         [emptyPlaceholder]="emptyPlaceholder"
         [selection]="multiModel"
         [selectionOptions]="options"
         [itemRenderer]="itemRenderer"
-        [componentRenderer]="componentRenderer"
+        [factoryRenderer]="factoryRenderer"
         [popupPositions]="popupPositions"
         [limit]="limit"
         [disabled]="disabled">
@@ -56,12 +56,12 @@
   </div>
   <div class="options-pane">
     <h3>Options</h3>
-    <material-checkbox [(checked)]="useLabelRenderer">
-      Use label renderer
+    <material-checkbox [(checked)]="useLabelFactory">
+      Use label factory
     </material-checkbox>
     <br>
-    <material-checkbox [(checked)]="useComponentRenderer">
-      Use component renderer
+    <material-checkbox [(checked)]="useFactoryRenderer">
+      Use factory renderer
     </material-checkbox>
     <br>
     <material-checkbox [(checked)]="filterSuggestions">

--- a/lib/src/material_auto_suggest_input_demo/material_auto_suggest_input_demo.html
+++ b/lib/src/material_auto_suggest_input_demo/material_auto_suggest_input_demo.html
@@ -108,7 +108,7 @@
         [displayBottomPanel]="false">
     </material-input>
     <br>
-    <label>Popup position: </label>
+    <label>Popup position: &ngsp; </label>
     <material-dropdown-select
         [buttonText]="popupPositionSelectButtonText"
         [selection]="popupPositionSelection"

--- a/lib/src/material_icon_demo/material_icon_demo.html
+++ b/lib/src/material_icon_demo/material_icon_demo.html
@@ -13,7 +13,8 @@
 <material-icon icon="more_horiz"></material-icon>
 
 <p>
-  See <a href="https://material.io/icons/" target="_blank">available icons</a>.
+  See &ngsp;
+  <a href="https://material.io/icons/" target="_blank">available icons</a>.
 </p>
 
 <h4>Using a string identifier</h4>
@@ -71,7 +72,7 @@
 <p>
   This
   <material-icon icon="flight_land"></material-icon>
-  is <b>not</b> aligned with surrounding text.
+  is &ngsp; <b>not</b> &ngsp; aligned with surrounding text.
 </p>
 <p>
   This

--- a/lib/src/material_popup_demo/material_popup_demo.html
+++ b/lib/src/material_popup_demo/material_popup_demo.html
@@ -46,9 +46,9 @@
 
 <h3>Limited Size</h3>
 <p>
-  Using the default <em>PercentagePopupSizeProvider</em> to limit max width
-  to be 70% of the viewport width and max height to be 50% of the viewport
-  height.
+  Using the default &ngsp; <em>PercentagePopupSizeProvider</em> &ngsp; to limit
+  max width to be 70% of the viewport width and max height to be 50% of the
+  viewport height.
 </p>
 <material-button class="blue"
                  raised

--- a/lib/src/material_select_demo/material_select_demo.dart
+++ b/lib/src/material_select_demo/material_select_demo.dart
@@ -18,7 +18,9 @@ import 'package:angular_components/model/selection/selection_model.dart';
 import 'package:angular_components/model/selection/selection_options.dart';
 import 'package:angular_components/model/selection/string_selection_options.dart';
 import 'package:angular_components/model/ui/display_name.dart';
-import 'package:angular_components/model/ui/has_renderer.dart';
+import 'package:angular_components/model/ui/has_factory.dart';
+
+import 'material_select_demo.template.dart' as demo;
 
 @Component(
   selector: 'material-select-demo',
@@ -125,7 +127,7 @@ class MaterialSelectDemoComponent {
       new CachingItemRenderer<Language>(
           (language) => "${language.label} (${language.code})");
 
-  bool useComponentRenderer = false;
+  bool useFactoryRenderer = false;
   bool useItemRenderer = false;
   bool useOptionGroup = false;
   bool withHeaderAndFooter = false;
@@ -214,8 +216,8 @@ class MaterialSelectDemoComponent {
   ItemRenderer<Language> get itemRenderer =>
       useItemRenderer ? _itemRenderer : _displayNameRenderer;
 
-  ComponentRenderer get componentRenderer =>
-      useComponentRenderer ? (_) => ExampleRendererComponent : null;
+  FactoryRenderer get factoryRenderer =>
+      useFactoryRenderer ? (_) => demo.ExampleRendererComponentNgFactory : null;
 
 // Label for the button for multi selection.
   String get multiSelectLanguageLabel {

--- a/lib/src/material_select_demo/material_select_demo.html
+++ b/lib/src/material_select_demo/material_select_demo.html
@@ -56,7 +56,7 @@
         [selection]="singleSelectModel"
         [options]="languageOptionsLong"
         [itemRenderer]="itemRenderer"
-        [componentRenderer]="componentRenderer"
+        [factoryRenderer]="factoryRenderer"
         [width]="width"
         [popupMatchInputWidth]="popupMatchInputWidth"
         [preferredPositions]="preferredPositions"
@@ -81,7 +81,7 @@
         [selection]="multiSelectModel"
         [options]="languageOptionsLong"
         [itemRenderer]="itemRenderer"
-        [componentRenderer]="componentRenderer"
+        [factoryRenderer]="factoryRenderer"
         [width]="width"
         [preferredPositions]="preferredPositions"
         [slide]="slide"
@@ -122,8 +122,8 @@
       Use item renderer
     </material-checkbox>
     <br>
-    <material-checkbox [(checked)]="useComponentRenderer">
-      Use component renderer
+    <material-checkbox [(checked)]="useFactoryRenderer">
+      Use factory renderer
     </material-checkbox>
     <br>
     <material-checkbox [(checked)]="useOptionGroup">

--- a/lib/src/material_tooltip_demo/material_tooltip_demo.html
+++ b/lib/src/material_tooltip_demo/material_tooltip_demo.html
@@ -29,15 +29,15 @@
    twoLineTooltip>
   webdev.dartlang.org</a>
 
-<p>Custom tooltip on some text.<em> Use this configuration sparingly, as the
-  tooltip text is intended for simple strings.</em>
+<p>Custom tooltip on some text. &ngsp; <em>Use this configuration sparingly, as the
+  tooltip text is intended for simple strings</em>.
 </p>
 <span tooltipTarget #ref="tooltipTarget">
   Explicitly declare a tooltip component<br/>
 </span>
 
 <material-tooltip-text [for]="ref">
-  Allows for &nbsp; <strong>formatted</strong> &nbsp; <em>text</em>.
+  Allows for &ngsp; <strong>formatted</strong> &ngsp; <em>text</em>.
 </material-tooltip-text>
 
 <h3>Card Tooltip</h3>

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -14,29 +14,27 @@ packages:
       name: angular
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "5.0.0-alpha+3"
+    version: "5.0.0-alpha+4"
   angular_ast:
     dependency: transitive
     description:
       name: angular_ast
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.1"
+    version: "0.4.2"
   angular_compiler:
     dependency: transitive
     description:
       name: angular_compiler
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.0-alpha+3"
+    version: "0.4.0-alpha+4"
   angular_components:
     dependency: "direct main"
     description:
-      path: "."
-      ref: github-sync
-      resolved-ref: c54000008736210638c2a8a8a4d4b830a7b994bd
-      url: "https://github.com/dart-lang/angular_components.git"
-    source: git
+      name: angular_components
+      url: "https://pub.dartlang.org"
+    source: hosted
     version: "0.9.0-alpha+3"
   angular_forms:
     dependency: "direct main"
@@ -44,7 +42,7 @@ packages:
       name: angular_forms
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.1-alpha+3"
+    version: "1.0.1-alpha+4"
   archive:
     dependency: transitive
     description:
@@ -72,14 +70,14 @@ packages:
       name: barback
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.15.2+13"
+    version: "0.15.2+14"
   bazel_worker:
     dependency: transitive
     description:
       name: bazel_worker
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.8"
+    version: "0.1.9"
   browser:
     dependency: "direct main"
     description:
@@ -93,49 +91,49 @@ packages:
       name: build
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.11.2"
+    version: "0.12.0"
   build_barback:
     dependency: transitive
     description:
       name: build_barback
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.5.0+1"
+    version: "0.5.0+2"
   build_config:
     dependency: transitive
     description:
       name: build_config
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.1"
+    version: "0.2.2+1"
   build_runner:
     dependency: "direct dev"
     description:
       name: build_runner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.7.4"
+    version: "0.7.7"
   build_web_compilers:
     dependency: "direct dev"
     description:
       name: build_web_compilers
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.0"
+    version: "0.2.1"
   built_collection:
     dependency: transitive
     description:
       name: built_collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.6.2"
+    version: "3.0.1"
   built_value:
     dependency: transitive
     description:
       name: built_value
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.3.3"
+    version: "4.6.1"
   charcode:
     dependency: transitive
     description:
@@ -156,7 +154,7 @@ packages:
       name: code_builder
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.4.0"
+    version: "3.0.0"
   code_transformers:
     dependency: transitive
     description:
@@ -240,7 +238,7 @@ packages:
       name: html
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.13.2+1"
+    version: "0.13.2+2"
   http:
     dependency: transitive
     description:
@@ -318,13 +316,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.1.2"
-  millisecond:
-    dependency: transitive
-    description:
-      name: millisecond
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.1.0"
   mime:
     dependency: transitive
     description:
@@ -338,7 +329,7 @@ packages:
       name: observable
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.20.4+2"
+    version: "0.20.4+3"
   package_config:
     dependency: transitive
     description:
@@ -387,14 +378,14 @@ packages:
       name: protobuf
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.6.0"
+    version: "0.7.0"
   quiver:
     dependency: transitive
     description:
       name: quiver
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.25.0"
+    version: "0.27.0"
   quiver_hashcode:
     dependency: transitive
     description:
@@ -415,14 +406,14 @@ packages:
       name: sass_builder
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.1"
+    version: "1.1.2"
   scratch_space:
     dependency: transitive
     description:
       name: scratch_space
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.0.1+2"
+    version: "0.0.1+3"
   shelf:
     dependency: transitive
     description:
@@ -436,7 +427,7 @@ packages:
       name: source_gen
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.7.3"
+    version: "0.7.4"
   source_maps:
     dependency: transitive
     description:
@@ -536,4 +527,4 @@ packages:
     source: hosted
     version: "2.1.13"
 sdks:
-  dart: "2.0.0-dev.15.0"
+  dart: ">=2.0.0-dev.15.0 <=2.0.0-dev.19.0"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -34,7 +34,7 @@ packages:
     description:
       path: "."
       ref: github-sync
-      resolved-ref: "966efd233d9b625adba3d392010f552b82d705c6"
+      resolved-ref: c54000008736210638c2a8a8a4d4b830a7b994bd
       url: "https://github.com/dart-lang/angular_components.git"
     source: git
     version: "0.9.0-alpha+3"
@@ -121,7 +121,7 @@ packages:
       name: build_web_compilers
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.1"
+    version: "0.2.0"
   built_collection:
     dependency: transitive
     description:
@@ -412,11 +412,9 @@ packages:
   sass_builder:
     dependency: "direct main"
     description:
-      path: "."
-      ref: HEAD
-      resolved-ref: "8cd926d3a3a5299e6473f138179b00a3a67a74c5"
-      url: "https://github.com/dart-league/sass_builder.git"
-    source: git
+      name: sass_builder
+      url: "https://pub.dartlang.org"
+    source: hosted
     version: "1.1.1"
   scratch_space:
     dependency: transitive

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -27,9 +27,9 @@ packages:
     version: "0.4.0-alpha+2"
   angular_components:
     description:
-      name: angular_components
-      url: "https://pub.dartlang.org"
-    source: hosted
+      path: "../angular_components"
+      relative: true
+    source: path
     version: "0.9.0-alpha+2"
   angular_forms:
     description:
@@ -61,12 +61,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.15.2+13"
-  bazel_worker:
-    description:
-      name: bazel_worker
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.1.8"
   browser:
     description:
       name: browser
@@ -85,24 +79,18 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.4.0+2"
-  build_compilers:
-    description:
-      name: build_compilers
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.1.0"
   build_config:
     description:
       name: build_config
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.1"
+    version: "0.2.1"
   build_runner:
     description:
       name: build_runner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.6.1"
+    version: "0.7.3"
   built_collection:
     description:
       name: built_collection
@@ -193,6 +181,12 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.1.5"
+  graphs:
+    description:
+      name: graphs
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.0"
   html:
     description:
       name: html
@@ -235,12 +229,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.6.1"
-  json_annotation:
-    description:
-      name: json_annotation
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.2.2"
   kernel:
     description:
       name: kernel
@@ -265,6 +253,12 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.1.2"
+  millisecond:
+    description:
+      name: millisecond
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.0"
   mime:
     description:
       name: mime
@@ -313,12 +307,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.3.3"
-  protobuf:
-    description:
-      name: protobuf
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.6.0"
   quiver:
     description:
       name: quiver
@@ -339,10 +327,10 @@ packages:
     version: "1.0.0-beta.4"
   sass_builder:
     description:
-      name: sass_builder
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.1.0"
+      path: "../sass_builder"
+      relative: true
+    source: path
+    version: "1.1.1"
   scratch_space:
     description:
       name: scratch_space
@@ -446,4 +434,4 @@ packages:
     source: hosted
     version: "2.1.13"
 sdks:
-  dart: ">=2.0.0-dev.3.0 <=2.0.0-dev.8.0"
+  dart: ">=2.0.0-dev.3.0 <=2.0.0-dev.13.0"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -2,436 +2,540 @@
 # See http://pub.dartlang.org/doc/glossary.html#lockfile
 packages:
   analyzer:
+    dependency: "direct overridden"
     description:
       name: analyzer
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.31.0-alpha.2"
   angular:
+    dependency: "direct main"
     description:
       name: angular
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "5.0.0-alpha+2"
+    version: "5.0.0-alpha+3"
   angular_ast:
+    dependency: transitive
     description:
       name: angular_ast
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.0"
+    version: "0.4.1"
   angular_compiler:
+    dependency: transitive
     description:
       name: angular_compiler
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.0-alpha+2"
+    version: "0.4.0-alpha+3"
   angular_components:
+    dependency: "direct main"
     description:
-      path: "../angular_components"
-      relative: true
-    source: path
-    version: "0.9.0-alpha+2"
+      path: "."
+      ref: github-sync
+      resolved-ref: "966efd233d9b625adba3d392010f552b82d705c6"
+      url: "https://github.com/dart-lang/angular_components.git"
+    source: git
+    version: "0.9.0-alpha+3"
   angular_forms:
+    dependency: "direct main"
     description:
       name: angular_forms
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.1-alpha+2"
+    version: "1.0.1-alpha+3"
   archive:
+    dependency: transitive
     description:
       name: archive
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.33"
   args:
+    dependency: transitive
     description:
       name: args
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.13.7"
   async:
+    dependency: transitive
     description:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.13.3"
+    version: "2.0.3"
   barback:
+    dependency: transitive
     description:
       name: barback
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.15.2+13"
+  bazel_worker:
+    dependency: transitive
+    description:
+      name: bazel_worker
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.8"
   browser:
+    dependency: "direct main"
     description:
       name: browser
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.10.0+2"
   build:
+    dependency: transitive
     description:
       name: build
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.11.2"
   build_barback:
+    dependency: transitive
     description:
       name: build_barback
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.0+2"
+    version: "0.5.0+1"
   build_config:
+    dependency: transitive
     description:
       name: build_config
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.2.1"
   build_runner:
+    dependency: "direct dev"
     description:
       name: build_runner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.7.3"
+    version: "0.7.4"
+  build_web_compilers:
+    dependency: "direct dev"
+    description:
+      name: build_web_compilers
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.1"
   built_collection:
+    dependency: transitive
     description:
       name: built_collection
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.6.2"
   built_value:
+    dependency: transitive
     description:
       name: built_value
       url: "https://pub.dartlang.org"
     source: hosted
     version: "4.3.3"
   charcode:
+    dependency: transitive
     description:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.1.1"
   cli_util:
+    dependency: transitive
     description:
       name: cli_util
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.1.2+1"
   code_builder:
+    dependency: transitive
     description:
       name: code_builder
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.4.0"
   code_transformers:
+    dependency: transitive
     description:
       name: code_transformers
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.5.1+3"
   collection:
+    dependency: transitive
     description:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.14.3"
+    version: "1.14.5"
   convert:
+    dependency: transitive
     description:
       name: convert
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.0.1"
   crypto:
+    dependency: transitive
     description:
       name: crypto
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.0.2+1"
   csslib:
+    dependency: transitive
     description:
       name: csslib
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.14.1"
   dart_style:
+    dependency: transitive
     description:
       name: dart_style
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.8"
+    version: "1.0.9"
   dart_to_js_script_rewriter:
+    dependency: "direct main"
     description:
       name: dart_to_js_script_rewriter
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.3"
   fixnum:
+    dependency: transitive
     description:
       name: fixnum
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.10.6"
   front_end:
+    dependency: transitive
     description:
       name: front_end
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.1.0-alpha.7"
   glob:
+    dependency: transitive
     description:
       name: glob
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.1.5"
   graphs:
+    dependency: transitive
     description:
       name: graphs
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.1.0"
   html:
+    dependency: transitive
     description:
       name: html
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.13.2"
+    version: "0.13.2+1"
   http:
+    dependency: transitive
     description:
       name: http
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.11.3+16"
   http_parser:
+    dependency: transitive
     description:
       name: http_parser
       url: "https://pub.dartlang.org"
     source: hosted
     version: "3.1.1"
   intl:
+    dependency: transitive
     description:
       name: intl
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.15.2"
   io:
+    dependency: transitive
     description:
       name: io
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.3.1"
   isolate:
+    dependency: transitive
     description:
       name: isolate
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.1.0"
   js:
+    dependency: transitive
     description:
       name: js
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.6.1"
+  json_annotation:
+    dependency: transitive
+    description:
+      name: json_annotation
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.2.2"
   kernel:
+    dependency: transitive
     description:
       name: kernel
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.3.0-alpha.4"
   logging:
+    dependency: transitive
     description:
       name: logging
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.11.3+1"
   matcher:
+    dependency: transitive
     description:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.12.1+4"
   meta:
+    dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.1.2"
   millisecond:
+    dependency: transitive
     description:
       name: millisecond
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.1.0"
   mime:
+    dependency: transitive
     description:
       name: mime
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.9.5"
   observable:
+    dependency: transitive
     description:
       name: observable
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.20.4+1"
+    version: "0.20.4+2"
   package_config:
+    dependency: transitive
     description:
       name: package_config
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.3"
   package_resolver:
+    dependency: transitive
     description:
       name: package_resolver
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.2"
   path:
+    dependency: transitive
     description:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.5.1"
   perf_api:
+    dependency: transitive
     description:
       name: perf_api
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.1.0"
   plugin:
+    dependency: transitive
     description:
       name: plugin
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.2.0+2"
   pool:
+    dependency: transitive
     description:
       name: pool
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.3"
+    version: "1.3.4"
+  protobuf:
+    dependency: transitive
+    description:
+      name: protobuf
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.6.0"
   quiver:
+    dependency: transitive
     description:
       name: quiver
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.25.0"
   quiver_hashcode:
+    dependency: transitive
     description:
       name: quiver_hashcode
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.0"
   sass:
+    dependency: transitive
     description:
       name: sass
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.0-beta.4"
   sass_builder:
+    dependency: "direct main"
     description:
-      path: "../sass_builder"
-      relative: true
-    source: path
+      path: "."
+      ref: HEAD
+      resolved-ref: "8cd926d3a3a5299e6473f138179b00a3a67a74c5"
+      url: "https://github.com/dart-league/sass_builder.git"
+    source: git
     version: "1.1.1"
   scratch_space:
+    dependency: transitive
     description:
       name: scratch_space
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.0.1+2"
   shelf:
+    dependency: transitive
     description:
       name: shelf
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.7.1"
+    version: "0.7.2"
   source_gen:
+    dependency: transitive
     description:
       name: source_gen
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.7.3"
   source_maps:
+    dependency: transitive
     description:
       name: source_maps
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.10.4"
   source_span:
+    dependency: transitive
     description:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.4.0"
   stack_trace:
+    dependency: transitive
     description:
       name: stack_trace
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.9.1"
   stream_channel:
+    dependency: transitive
     description:
       name: stream_channel
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.6.3"
   stream_transform:
+    dependency: transitive
     description:
       name: stream_transform
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.0.9"
   string_scanner:
+    dependency: transitive
     description:
       name: string_scanner
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.2"
   tuple:
+    dependency: transitive
     description:
       name: tuple
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.1"
   typed_data:
+    dependency: transitive
     description:
       name: typed_data
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.1.5"
   unittest:
+    dependency: transitive
     description:
       name: unittest
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.11.7"
   utf:
+    dependency: transitive
     description:
       name: utf
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.9.0+3"
   uuid:
+    dependency: transitive
     description:
       name: uuid
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.5.3"
   watcher:
+    dependency: transitive
     description:
       name: watcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.9.7+4"
+    version: "0.9.7+6"
   webdriver:
+    dependency: "direct dev"
     description:
       name: webdriver
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.2.3"
   yaml:
+    dependency: transitive
     description:
       name: yaml
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.1.13"
 sdks:
-  dart: ">=2.0.0-dev.3.0 <=2.0.0-dev.13.0"
+  dart: "2.0.0-dev.15.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,8 +12,15 @@ dependencies:
 dependency_overrides:
   # Necessary with angular: 5.0.0-alpha+1 dependency.
   analyzer: ^0.31.0-alpha.1
+  angular_components:
+    path: ../angular_components
+#  build_runner: ^0.7.0
+  build_barback: ">=0.4.0+2 < 0.6.0"
+  sass_builder:
+    path: ../sass_builder
 dev_dependencies:
   webdriver: ^1.2.1
+  build_runner: ^0.7.0
 transformers:
 - sass_builder
 - angular:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,9 +3,9 @@ description: An example app using the angular_components package.
 environment:
   sdk: '>=2.0.0-dev.3.0 <2.0.0'
 dependencies:
-  angular: 5.0.0-alpha+2
-  angular_components: 0.9.0-alpha+2
-  angular_forms: 1.0.1-alpha+2
+  angular: 5.0.0-alpha+3
+  angular_components: 0.9.0-alpha+3
+  angular_forms: 1.0.1-alpha+3
   browser: ^0.10.0
   dart_to_js_script_rewriter: ^1.0.1
   sass_builder: ^1.1.0
@@ -13,14 +13,15 @@ dependency_overrides:
   # Necessary with angular: 5.0.0-alpha+1 dependency.
   analyzer: ^0.31.0-alpha.1
   angular_components:
-    path: ../angular_components
-#  build_runner: ^0.7.0
-  build_barback: ">=0.4.0+2 < 0.6.0"
+    git:
+      url: https://github.com/dart-lang/angular_components.git
+      ref: github-sync
   sass_builder:
-    path: ../sass_builder
+    git: https://github.com/dart-league/sass_builder.git
 dev_dependencies:
   webdriver: ^1.2.1
   build_runner: ^0.7.0
+  build_web_compilers: ^0.1.1
 transformers:
 - sass_builder
 - angular:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,12 +3,12 @@ description: An example app using the angular_components package.
 environment:
   sdk: '>=2.0.0-dev.3.0 <2.0.0'
 dependencies:
-  angular: 5.0.0-alpha+3
+  angular: 5.0.0-alpha+4
   angular_components: 0.9.0-alpha+3
-  angular_forms: 1.0.1-alpha+3
+  angular_forms: 1.0.1-alpha+4
   browser: ^0.10.0
   dart_to_js_script_rewriter: ^1.0.1
-  sass_builder: ^1.1.1
+  sass_builder: 1.1.2
 dev_dependencies:
   webdriver: ^1.2.1
   build_runner: ^0.7.0
@@ -16,10 +16,6 @@ dev_dependencies:
 dependency_overrides:
   # Necessary with angular: 5.0.0-alpha+1 dependency.
   analyzer: ^0.31.0-alpha.1
-  angular_components:
-    git:
-      url: https://github.com/dart-lang/angular_components.git
-      ref: github-sync
 transformers:
 - sass_builder
 - angular:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,7 +8,7 @@ dependencies:
   angular_forms: 1.0.1-alpha+4
   browser: ^0.10.0
   dart_to_js_script_rewriter: ^1.0.1
-  sass_builder: 1.1.2
+  sass_builder: ^1.1.2
 dev_dependencies:
   webdriver: ^1.2.1
   build_runner: ^0.7.0
@@ -17,6 +17,8 @@ dependency_overrides:
   # Necessary with angular: 5.0.0-alpha+1 dependency.
   analyzer: ^0.31.0-alpha.1
 transformers:
+# build_runner users will not need these transformers and can skip the
+# compilation when running pub get by using the --no-precompile flag.
 - sass_builder
 - angular:
     entry_points: web/main.dart

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,7 +8,11 @@ dependencies:
   angular_forms: 1.0.1-alpha+3
   browser: ^0.10.0
   dart_to_js_script_rewriter: ^1.0.1
-  sass_builder: ^1.1.0
+  sass_builder: ^1.1.1
+dev_dependencies:
+  webdriver: ^1.2.1
+  build_runner: ^0.7.0
+  build_web_compilers: ^0.2.0
 dependency_overrides:
   # Necessary with angular: 5.0.0-alpha+1 dependency.
   analyzer: ^0.31.0-alpha.1
@@ -16,12 +20,6 @@ dependency_overrides:
     git:
       url: https://github.com/dart-lang/angular_components.git
       ref: github-sync
-  sass_builder:
-    git: https://github.com/dart-league/sass_builder.git
-dev_dependencies:
-  webdriver: ^1.2.1
-  build_runner: ^0.7.0
-  build_web_compilers: ^0.1.1
 transformers:
 - sass_builder
 - angular:


### PR DESCRIPTION
* Update dependencies to support angular_components: 0.9.0-alpha+3.
* Migrate Material Select and Auto-suggest examples to use Factory pattern.