### PR TITLE
pin the analyzer version due to breakage

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,7 @@ dev_dependencies:
   build_web_compilers: ^0.2.0
 dependency_overrides:
   # Necessary with angular: 5.0.0-alpha+1 dependency.
-  analyzer: ^0.31.0-alpha.1
+  analyzer: 0.31.0-alpha.1
 transformers:
 # build_runner users will not need these transformers and can skip the
 # compilation when running pub get by using the --no-precompile flag.


### PR DESCRIPTION
looks like alpha.2 is causing some issues, we can investigate this after dartconf

cc @kevmoo this fixes the issue you were talking about

cc @matanlurey @alorenzen 