### PR TITLE
Add back dart2js dump-info

### DIFF
--- a/example/angular_components_example/build.yaml
+++ b/example/angular_components_example/build.yaml
@@ -12,6 +12,9 @@ targets:
         enabled: True
       angular_gallery_section:
         enabled: False
+      build_web_compilers|dart2js_archive_extractor:
+        options:
+          filter_outputs: false
       build_web_compilers|entrypoint:
         generate_for:
         - web/main.dart
@@ -21,3 +24,4 @@ targets:
           - --minify
           - --trust-type-annotations
           - --trust-primitives
+          - --dump-info


### PR DESCRIPTION
Was accidentally removed from the build output on last update.